### PR TITLE
feat: add community trends tool

### DIFF
--- a/fpl-mcp-server/README.md
+++ b/fpl-mcp-server/README.md
@@ -7,6 +7,7 @@ A Model Context Protocol (MCP) server that provides Fantasy Premier League data 
 - **get_my_squad**: Get your current 15-player squad with captain, budget, and chip info
 - **get_fixtures**: Get Premier League fixtures with difficulty ratings
 - **search_players**: Search for transfer targets by name, position, price, form, etc.
+- **get_community_trends**: Aggregate FPL community insights from Reddit, Twitter, and blogs with sentiment analysis
 
 ## Setup
 
@@ -23,6 +24,7 @@ npm install
 |----------|-------------|----------|
 | `FPL_MANAGER_ID` | Your FPL manager ID (from URL) | For get_my_squad |
 | `FPL_COOKIE` | Browser cookie for authenticated endpoints | For full features |
+| `BRAVE_SEARCH_API_KEY` | Brave Search API key for community trends | For get_community_trends |
 
 **Finding your Manager ID:**
 1. Go to https://fantasy.premierleague.com/my-team
@@ -33,6 +35,12 @@ npm install
 2. Open DevTools (F12) → Network tab
 3. Make any request to FPL
 4. Copy the `Cookie` header value
+
+**Getting your Brave Search API key (for community trends):**
+1. Go to https://brave.com/search/api/
+2. Sign up for free (2000 queries/month, no credit card required)
+3. Copy your API key
+4. Set in your shell: `export BRAVE_SEARCH_API_KEY=your-key-here`
 
 ### 3. Run the server
 
@@ -57,7 +65,8 @@ Add to your `.mcp.json` (project root or global config):
       "args": ["tsx", "fpl-mcp-server/src/index.ts"],
       "cwd": "/path/to/fpl-ai-assist",
       "env": {
-        "FPL_COOKIE": "your-cookie-here"
+        "FPL_COOKIE": "your-cookie-here",
+        "BRAVE_SEARCH_API_KEY": "your-brave-api-key-here"
       }
     }
   }
@@ -112,6 +121,25 @@ Search the player database for transfer targets.
 - Next 3 fixtures for each player
 - Ownership percentages
 
+### get_community_trends
+
+Aggregate FPL community insights from Reddit, Twitter, and FPL blogs. Use this weekly to catch players the stats might miss - the "eye test" picks, tactical changes, or emerging differentials being discussed.
+
+**Parameters:**
+- `topic` (optional): Focus area - "transfers", "captaincy", "differentials", or "general" (default)
+- `position` (optional): Filter by position - GK, DEF, MID, FWD
+- `player_name` (optional): Focus on a specific player
+- `gameweek` (optional): Gameweek number (defaults to current)
+
+**Returns:**
+- Trending players with buy/sell/hold/watch sentiment
+- Number of mentions across sources
+- Reasons extracted from discussions
+- Source links for verification
+- Hot topics in the FPL community
+
+**Note:** Requires `BRAVE_SEARCH_API_KEY` environment variable. Without it, returns setup instructions.
+
 ## Caching
 
 The server uses SQLite caching with these TTLs:
@@ -122,5 +150,6 @@ The server uses SQLite caching with these TTLs:
 | Fixtures | 1 hour |
 | Your squad | 5 minutes |
 | Live scores | 30 seconds |
+| Community trends | 6 hours |
 
 Cache is stored in `./data/cache.db` and persists across restarts.

--- a/fpl-mcp-server/src/cache/keys.ts
+++ b/fpl-mcp-server/src/cache/keys.ts
@@ -6,6 +6,7 @@ export const TTL = {
   LIVE: 30 * 1000, // 30 seconds - real-time during matches
   MANAGER_INFO: 60 * 60 * 1000, // 1 hour - rarely changes
   PICKS: 5 * 60 * 1000, // 5 minutes - same as my_team
+  COMMUNITY_TRENDS: 6 * 60 * 60 * 1000, // 6 hours - community sentiment doesn't change often
 } as const;
 
 // Cache key generators
@@ -17,4 +18,5 @@ export const CACHE_KEYS = {
   picks: (managerId: number, gw: number) => `cache:picks:${managerId}:${gw}`,
   managerInfo: (managerId: number) => `cache:manager:${managerId}`,
   live: (gw: number) => `cache:live:${gw}`,
+  communityTrends: (topic: string, gw: number) => `cache:trends:${topic}:${gw}`,
 } as const;

--- a/fpl-mcp-server/src/index.ts
+++ b/fpl-mcp-server/src/index.ts
@@ -22,6 +22,9 @@ import {
   getFixtureDifficultyTool,
   handleGetFixtureDifficulty,
   getFixtureDifficultySchema,
+  getCommunityTrendsTool,
+  handleGetCommunityTrends,
+  getCommunityTrendsSchema,
 } from "./tools/index.js";
 
 // Initialize cache and API client
@@ -46,7 +49,7 @@ const server = new Server(
 
 // Register tool list handler
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [getMySquadTool, getFixturesTool, searchPlayersTool, getFixtureDifficultyTool],
+  tools: [getMySquadTool, getFixturesTool, searchPlayersTool, getFixtureDifficultyTool, getCommunityTrendsTool],
 }));
 
 // Register tool call handler
@@ -88,6 +91,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const input = getFixtureDifficultySchema.parse(args);
         const result = await handleGetFixtureDifficulty(input, client, cache);
         logToolResult(name, `Analyzed ${result.team} fixtures GW${result.analysis_range.from}-${result.analysis_range.to}`);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "get_community_trends": {
+        const input = getCommunityTrendsSchema.parse(args);
+        const result = await handleGetCommunityTrends(input, client, cache);
+        if ("error" in result) {
+          logToolResult(name, `Error: ${result.error}`);
+        } else {
+          logToolResult(name, `Found ${result.trending_players.length} trending players`);
+        }
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
         };

--- a/fpl-mcp-server/src/tools/get-community-trends.ts
+++ b/fpl-mcp-server/src/tools/get-community-trends.ts
@@ -1,0 +1,436 @@
+import { z } from "zod";
+import type { FPLApiClient } from "../api/client.js";
+import { getCurrentGameweek } from "../api/client.js";
+import { FPLCache, cachedFetch } from "../cache/sqlite.js";
+import { TTL, CACHE_KEYS } from "../cache/keys.js";
+import type {
+  BootstrapStatic,
+  FPLPlayer,
+  CommunityTrendsResponse,
+  TrendingPlayer,
+  TrendingPlayerSource,
+} from "../types/index.js";
+
+// Brave Search API response types
+interface BraveSearchResult {
+  title: string;
+  url: string;
+  description: string;
+}
+
+interface BraveSearchResponse {
+  web?: {
+    results: BraveSearchResult[];
+  };
+}
+
+export const getCommunityTrendsSchema = z.object({
+  topic: z
+    .enum(["transfers", "captaincy", "differentials", "general"])
+    .optional()
+    .default("general")
+    .describe("Focus area: transfers, captaincy, differentials, or general"),
+  position: z
+    .enum(["GK", "DEF", "MID", "FWD"])
+    .optional()
+    .describe("Filter by position"),
+  player_name: z.string().optional().describe("Focus on specific player"),
+  gameweek: z.number().optional().describe("Gameweek (default: current)"),
+});
+
+export type GetCommunityTrendsInput = z.infer<typeof getCommunityTrendsSchema>;
+
+export const getCommunityTrendsTool = {
+  name: "get_community_trends",
+  description: `Get FPL community trends and buzz from Reddit, Twitter, and FPL blogs.
+Use this weekly to catch players the stats might miss - the "eye test" picks,
+tactical changes, or emerging differentials being discussed by the community.
+
+Returns:
+- Trending players with buy/sell/hold sentiment
+- Source links for verification
+- Hot topics in the FPL community`,
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      topic: {
+        type: "string",
+        enum: ["transfers", "captaincy", "differentials", "general"],
+        description: "Focus area: transfers, captaincy, differentials, or general",
+      },
+      position: {
+        type: "string",
+        enum: ["GK", "DEF", "MID", "FWD"],
+        description: "Filter by position",
+      },
+      player_name: {
+        type: "string",
+        description: "Focus on specific player",
+      },
+      gameweek: {
+        type: "number",
+        description: "Gameweek (default: current)",
+      },
+    },
+    required: [],
+  },
+};
+
+// Sentiment indicators
+const SENTIMENT_PATTERNS = {
+  buy: [
+    "bringing in",
+    "must have",
+    "essential",
+    "bandwagon",
+    "getting in",
+    "buy",
+    "pick up",
+    "transfer in",
+    "signing",
+    "worth it",
+    "great value",
+    "differential",
+    "hidden gem",
+    "underrated",
+  ],
+  sell: [
+    "getting rid",
+    "selling",
+    "avoid",
+    "trap",
+    "transfer out",
+    "drop",
+    "bench",
+    "not worth",
+    "overpriced",
+    "rotation risk",
+    "injured",
+    "out for",
+  ],
+  hold: [
+    "keeping",
+    "hold",
+    "wait and see",
+    "patience",
+    "stick with",
+    "trust",
+    "long term",
+  ],
+  watch: [
+    "monitor",
+    "could rise",
+    "one to watch",
+    "keep an eye",
+    "wait for",
+    "potential",
+    "emerging",
+    "breaking through",
+  ],
+};
+
+export async function handleGetCommunityTrends(
+  input: GetCommunityTrendsInput,
+  client: FPLApiClient,
+  cache: FPLCache
+): Promise<CommunityTrendsResponse | { error: string; setup_instructions: string }> {
+  const apiKey = process.env.BRAVE_SEARCH_API_KEY;
+
+  if (!apiKey) {
+    return {
+      error: "BRAVE_SEARCH_API_KEY not configured",
+      setup_instructions:
+        "Get a free API key at https://brave.com/search/api/ and set BRAVE_SEARCH_API_KEY environment variable",
+    };
+  }
+
+  const topic = input.topic ?? "general";
+  const position = input.position;
+  const playerName = input.player_name;
+
+  // Get current gameweek from bootstrap data
+  const bootstrap = await cachedFetch<BootstrapStatic>(
+    cache,
+    CACHE_KEYS.bootstrap(),
+    TTL.BOOTSTRAP,
+    () => client.getBootstrapStatic()
+  );
+  const gameweek = input.gameweek ?? getCurrentGameweek(bootstrap.events);
+
+  // Check cache first
+  const cacheKey = CACHE_KEYS.communityTrends(
+    `${topic}-${position ?? "all"}-${playerName ?? "all"}`,
+    gameweek
+  );
+
+  const cached = cache.get<CommunityTrendsResponse>(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  // Build search queries based on topic
+  const queries = buildSearchQueries(topic, position, playerName, gameweek);
+
+  // Execute searches
+  const allResults: BraveSearchResult[] = [];
+  let queriesMade = 0;
+  let warning: string | undefined;
+
+  for (const query of queries) {
+    try {
+      const results = await executeBraveSearch(query, apiKey);
+      allResults.push(...results);
+      queriesMade++;
+    } catch (error) {
+      warning = `Some searches failed: ${error instanceof Error ? error.message : String(error)}`;
+    }
+  }
+
+  // Parse results for player mentions and sentiment
+  const trendingPlayers = extractTrendingPlayers(allResults, bootstrap.elements, position);
+
+  // Extract hot topics
+  const hotTopics = extractHotTopics(allResults);
+
+  const response: CommunityTrendsResponse = {
+    query: {
+      topic,
+      position,
+      gameweek,
+    },
+    fetched_at: new Date().toISOString(),
+    trending_players: trendingPlayers,
+    hot_topics: hotTopics,
+    data_source: {
+      search_provider: "Brave Search",
+      queries_made: queriesMade,
+      warning,
+    },
+  };
+
+  // Cache the response
+  cache.set(cacheKey, response, TTL.COMMUNITY_TRENDS);
+
+  return response;
+}
+
+function buildSearchQueries(
+  topic: string,
+  position: string | undefined,
+  playerName: string | undefined,
+  gameweek: number
+): string[] {
+  const queries: string[] = [];
+  const year = new Date().getFullYear();
+  const positionStr = position ? ` ${position.toLowerCase()}` : "";
+
+  if (playerName) {
+    // Player-specific searches
+    queries.push(`FPL "${playerName}" transfer advice ${year}`);
+    queries.push(`"${playerName}" fantasy premier league reddit`);
+    return queries;
+  }
+
+  switch (topic) {
+    case "transfers":
+      queries.push(`FPL gameweek ${gameweek} transfers Reddit ${year}`);
+      queries.push(`FPL${positionStr} transfer targets gameweek ${gameweek}`);
+      queries.push(`fantasy premier league who to buy${positionStr} ${year}`);
+      break;
+    case "captaincy":
+      queries.push(`FPL gameweek ${gameweek} captain Reddit`);
+      queries.push(`FPL who to captain GW${gameweek}`);
+      queries.push(`fantasy premier league captain picks ${year}`);
+      break;
+    case "differentials":
+      queries.push(`FPL differentials${positionStr} gameweek ${gameweek}`);
+      queries.push(`FPL hidden gems${positionStr} ${year}`);
+      queries.push(`fantasy premier league low ownership picks`);
+      break;
+    default:
+      queries.push(`FPL gameweek ${gameweek} Reddit discussion`);
+      queries.push(`fantasy premier league tips${positionStr} ${year}`);
+      break;
+  }
+
+  return queries;
+}
+
+async function executeBraveSearch(query: string, apiKey: string): Promise<BraveSearchResult[]> {
+  const url = new URL("https://api.search.brave.com/res/v1/web/search");
+  url.searchParams.set("q", query);
+  url.searchParams.set("count", "10");
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Accept: "application/json",
+      "X-Subscription-Token": apiKey,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Brave Search API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as BraveSearchResponse;
+  return data.web?.results ?? [];
+}
+
+function extractTrendingPlayers(
+  results: BraveSearchResult[],
+  players: FPLPlayer[],
+  positionFilter: string | undefined
+): TrendingPlayer[] {
+  // Build player name lookup map
+  const playerMap = new Map<string, FPLPlayer>();
+  for (const player of players) {
+    // Match by web_name (common usage), full name, and surname
+    playerMap.set(player.web_name.toLowerCase(), player);
+    playerMap.set(`${player.first_name} ${player.second_name}`.toLowerCase(), player);
+    playerMap.set(player.second_name.toLowerCase(), player);
+  }
+
+  // Position mapping
+  const positionTypeMap: Record<string, number> = {
+    GK: 1,
+    DEF: 2,
+    MID: 3,
+    FWD: 4,
+  };
+
+  // Track player mentions
+  const mentions = new Map<
+    string,
+    {
+      player: FPLPlayer;
+      count: number;
+      sentimentScores: Record<string, number>;
+      reasons: Set<string>;
+      sources: TrendingPlayerSource[];
+    }
+  >();
+
+  for (const result of results) {
+    const text = `${result.title} ${result.description}`.toLowerCase();
+
+    // Check each player
+    for (const [name, player] of playerMap) {
+      // Skip if position filter doesn't match
+      if (positionFilter && player.element_type !== positionTypeMap[positionFilter]) {
+        continue;
+      }
+
+      // Check if player is mentioned (need at least 3 chars to avoid false positives)
+      if (name.length >= 3 && text.includes(name)) {
+        const key = player.web_name;
+
+        if (!mentions.has(key)) {
+          mentions.set(key, {
+            player,
+            count: 0,
+            sentimentScores: { buy: 0, sell: 0, hold: 0, watch: 0 },
+            reasons: new Set(),
+            sources: [],
+          });
+        }
+
+        const data = mentions.get(key)!;
+        data.count++;
+
+        // Analyze sentiment
+        for (const [sentiment, patterns] of Object.entries(SENTIMENT_PATTERNS)) {
+          for (const pattern of patterns) {
+            if (text.includes(pattern)) {
+              data.sentimentScores[sentiment]++;
+              data.reasons.add(pattern);
+            }
+          }
+        }
+
+        // Determine source type
+        let sourceType: TrendingPlayerSource["source_type"] = "other";
+        if (result.url.includes("reddit.com")) sourceType = "reddit";
+        else if (result.url.includes("twitter.com") || result.url.includes("x.com")) sourceType = "twitter";
+        else if (
+          result.url.includes("fantasyfootballscout") ||
+          result.url.includes("fplstatistics") ||
+          result.url.includes("thefplwire") ||
+          result.url.includes("blog")
+        )
+          sourceType = "blog";
+
+        // Avoid duplicate sources
+        if (!data.sources.some((s) => s.url === result.url)) {
+          data.sources.push({
+            title: result.title,
+            url: result.url,
+            source_type: sourceType,
+          });
+        }
+      }
+    }
+  }
+
+  // Convert to trending players array
+  const trendingPlayers: TrendingPlayer[] = [];
+
+  for (const [, data] of mentions) {
+    // Determine dominant sentiment
+    const scores = data.sentimentScores;
+    const maxScore = Math.max(scores.buy, scores.sell, scores.hold, scores.watch);
+    let sentiment: TrendingPlayer["sentiment"] = "watch";
+
+    if (maxScore > 0) {
+      if (scores.buy === maxScore) sentiment = "buy";
+      else if (scores.sell === maxScore) sentiment = "sell";
+      else if (scores.hold === maxScore) sentiment = "hold";
+      else sentiment = "watch";
+    }
+
+    trendingPlayers.push({
+      player_name: data.player.web_name,
+      player_id: data.player.id,
+      sentiment,
+      mentions: data.count,
+      reasons: Array.from(data.reasons).slice(0, 5),
+      sources: data.sources.slice(0, 3),
+    });
+  }
+
+  // Sort by mention count
+  trendingPlayers.sort((a, b) => b.mentions - a.mentions);
+
+  // Return top 10
+  return trendingPlayers.slice(0, 10);
+}
+
+function extractHotTopics(results: BraveSearchResult[]): string[] {
+  const topicPatterns = [
+    { pattern: /salah\s+vs?\s+haaland/i, topic: "Salah vs Haaland captaincy" },
+    { pattern: /dgw|double\s+gameweek/i, topic: "Double Gameweek planning" },
+    { pattern: /bgw|blank\s+gameweek/i, topic: "Blank Gameweek navigation" },
+    { pattern: /wildcard/i, topic: "Wildcard timing" },
+    { pattern: /free\s+hit/i, topic: "Free Hit usage" },
+    { pattern: /bench\s+boost/i, topic: "Bench Boost strategy" },
+    { pattern: /triple\s+captain/i, topic: "Triple Captain picks" },
+    { pattern: /price\s+rise|price\s+change/i, topic: "Price rises/falls" },
+    { pattern: /template/i, topic: "Template team discussion" },
+    { pattern: /rotation|roulette/i, topic: "Rotation concerns" },
+    { pattern: /injury|injured/i, topic: "Injury updates" },
+    { pattern: /presser|press\s+conference/i, topic: "Press conference insights" },
+  ];
+
+  const foundTopics = new Set<string>();
+
+  for (const result of results) {
+    const text = `${result.title} ${result.description}`;
+
+    for (const { pattern, topic } of topicPatterns) {
+      if (pattern.test(text)) {
+        foundTopics.add(topic);
+      }
+    }
+  }
+
+  return Array.from(foundTopics).slice(0, 5);
+}

--- a/fpl-mcp-server/src/tools/index.ts
+++ b/fpl-mcp-server/src/tools/index.ts
@@ -2,3 +2,4 @@ export { getMySquadTool, handleGetMySquad, getMySquadSchema } from "./get-my-squ
 export { getFixturesTool, handleGetFixtures, getFixturesSchema } from "./get-fixtures.js";
 export { searchPlayersTool, handleSearchPlayers, searchPlayersSchema } from "./search-players.js";
 export { getFixtureDifficultyTool, handleGetFixtureDifficulty, getFixtureDifficultySchema } from "./get-fixture-difficulty.js";
+export { getCommunityTrendsTool, handleGetCommunityTrends, getCommunityTrendsSchema } from "./get-community-trends.js";

--- a/fpl-mcp-server/src/types/index.ts
+++ b/fpl-mcp-server/src/types/index.ts
@@ -293,6 +293,39 @@ export const POSITION_MAP: Record<number, "GK" | "DEF" | "MID" | "FWD"> = {
   4: "FWD",
 };
 
+// Community Trends types
+
+export interface TrendingPlayerSource {
+  title: string;
+  url: string;
+  source_type: "reddit" | "twitter" | "blog" | "other";
+}
+
+export interface TrendingPlayer {
+  player_name: string;
+  player_id?: number;
+  sentiment: "buy" | "sell" | "hold" | "watch";
+  mentions: number;
+  reasons: string[];
+  sources: TrendingPlayerSource[];
+}
+
+export interface CommunityTrendsResponse {
+  query: {
+    topic?: string;
+    position?: string;
+    gameweek: number;
+  };
+  fetched_at: string;
+  trending_players: TrendingPlayer[];
+  hot_topics: string[];
+  data_source: {
+    search_provider: string;
+    queries_made: number;
+    warning?: string;
+  };
+}
+
 // Helper function
 export function toMillions(tenths: number): number {
   return Math.round((tenths / 10) * 10) / 10;


### PR DESCRIPTION
## Summary

- Add `get_community_trends` tool that aggregates FPL community insights from Reddit, Twitter, and FPL blogs
- Uses Brave Search API (free tier: 2000 queries/month) to search for FPL-related discussions
- Extracts trending players with sentiment analysis (buy/sell/hold/watch)
- Detects hot topics like DGW planning, captaincy debates, rotation concerns
- Includes source links for user verification

## Changes

- **New file**: `src/tools/get-community-trends.ts` - Main tool implementation
- **Modified**: `src/types/index.ts` - Added `TrendingPlayer` and `CommunityTrendsResponse` types
- **Modified**: `src/cache/keys.ts` - Added 6-hour TTL for community trends
- **Modified**: `src/tools/index.ts` - Export new tool
- **Modified**: `src/index.ts` - Register tool handler
- **Modified**: `README.md` - Documentation and setup instructions

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Call `get_community_trends` with no params - should return general trends
- [ ] Call with `topic: "captaincy"` - should return captain-focused results
- [ ] Call with `position: "MID"` - should filter to midfielders
- [ ] Verify caching works (second call should be faster)
- [ ] Verify graceful handling when `BRAVE_SEARCH_API_KEY` is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)